### PR TITLE
Update chess opening classifications

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -149,6 +149,19 @@ const OPENING_FAMILY_SYNONYMS = {
   // Grunfeld without umlaut
   'grunfeld': 'Grünfeld',
   'neo grunfeld': 'Neo Grunfeld',
+  // King's/Queen's variants without apostrophes
+  'kings indian defense': "King's Indian Defense",
+  'kings indian attack': "King's Indian Attack",
+  'kings fianchetto opening': "King's Fianchetto",
+  'kings fianchetto': "King's Fianchetto",
+  'queens indian defense': "Queen's Indian",
+  'queens indian': "Queen's Indian",
+  // Reversed Sicilian is an English Opening family
+  'reversed sicilian': 'English',
+  // St. George Defense maps to Owen's Defense
+  'st george defense': 'Owen',
+  'st. george defense': 'Owen',
+  'saint george defense': 'Owen',
   // Kings Pawn variations
   "king's pawn opening": "King's Pawn",
   // Van 't Kruijs variants


### PR DESCRIPTION
Add synonyms to `OPENING_FAMILY_SYNONYMS` to correctly categorize various chess opening names, including apostrophe-less "King(s)/Queen(s)" variants, St. George Defense, Reversed Sicilian, and King's Fianchetto forms.

---
<a href="https://cursor.com/background-agent?bcId=bc-3052216a-5512-47ae-90e1-3b798912905b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3052216a-5512-47ae-90e1-3b798912905b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

